### PR TITLE
Add initialiser with default values for SegmentioOptions

### DIFF
--- a/Segmentio/Source/SegmentioOptions.swift
+++ b/Segmentio/Source/SegmentioOptions.swift
@@ -168,29 +168,17 @@ public struct SegmentioOptions {
     var states: SegmentioStates
     var animationDuration: CFTimeInterval
     
-    public init() {
-        self.backgroundColor = .lightGray
-        self.maxVisibleItems = 4
-        self.scrollEnabled = true
-        
-        self.horizontalSeparatorOptions = SegmentioHorizontalSeparatorOptions()
-        self.verticalSeparatorOptions = SegmentioVerticalSeparatorOptions()
-        
-        self.indicatorOptions = SegmentioIndicatorOptions()
-        
-        self.imageContentMode = .center
-        self.labelTextAlignment = .center
-        self.labelTextNumberOfLines = 0
-        
-        self.states = SegmentioStates(
-            defaultState: SegmentioState(),
-            selectedState: SegmentioState(),
-            highlightedState: SegmentioState()
-        )
-        self.animationDuration = 0.1
-    }
-    
-    public init(backgroundColor: UIColor, maxVisibleItems: Int, scrollEnabled: Bool, indicatorOptions: SegmentioIndicatorOptions?, horizontalSeparatorOptions: SegmentioHorizontalSeparatorOptions?, verticalSeparatorOptions: SegmentioVerticalSeparatorOptions?, imageContentMode: UIViewContentMode, labelTextAlignment: NSTextAlignment, labelTextNumberOfLines: Int, segmentStates: SegmentioStates, animationDuration: CFTimeInterval) {
+    public init(backgroundColor: UIColor = .lightGray,
+                maxVisibleItems: Int = 4,
+                scrollEnabled: Bool = true,
+                indicatorOptions: SegmentioIndicatorOptions? = SegmentioIndicatorOptions(),
+                horizontalSeparatorOptions: SegmentioHorizontalSeparatorOptions? = SegmentioHorizontalSeparatorOptions(),
+                verticalSeparatorOptions: SegmentioVerticalSeparatorOptions? = SegmentioVerticalSeparatorOptions(),
+                imageContentMode: UIViewContentMode = .center,
+                labelTextAlignment: NSTextAlignment = .center,
+                labelTextNumberOfLines: Int = 0,
+                segmentStates: SegmentioStates = SegmentioStates(defaultState: SegmentioState(), selectedState: SegmentioState(), highlightedState: SegmentioState()),
+                animationDuration: CFTimeInterval = 0.1) {
         self.backgroundColor = backgroundColor
         self.maxVisibleItems = maxVisibleItems
         self.scrollEnabled = scrollEnabled
@@ -203,5 +191,4 @@ public struct SegmentioOptions {
         self.states = segmentStates
         self.animationDuration = animationDuration
     }
-    
 }


### PR DESCRIPTION
Previously `SegmentioOptions` had two initializers: with zero parameters and with all parameters. They can be combined, so we could have initializer  with default values. This approach gives us opportunities to create new instance of `SegmentioOptions` with default values except some. For example:

```
let options = SegmentioOptions(backgroundColor = .black)
```

So we have all default values except background color. With previous setup it would take twice as much lines of code(however it's only two lines :-) ):
```
let options = SegmentioOptions()
options.backgroundColor = .black
```