### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.1
 
 import PackageDescription
 


### PR DESCRIPTION
Currently when importing Segmentio from Swift Package Manager in Xcode 11, the compiler complains about a usage of `bringSubviewToFront`. Updating `swift-tools-version` resolves the issue and allows the library to be used this way. 

I'd also suggest tagging versions so SPM can pick them up.