### PR TITLE
Add inset style options

### DIFF
--- a/Segmentio/Source/Segmentio.swift
+++ b/Segmentio/Source/Segmentio.swift
@@ -80,7 +80,6 @@ open class Segmentio: UIView {
     
     private func commonInit() {
         let layout = UICollectionViewFlowLayout()
-        layout.sectionInset = UIEdgeInsets.zero
         layout.scrollDirection = .horizontal
         layout.minimumInteritemSpacing = 0
         layout.minimumLineSpacing = 0
@@ -654,7 +653,31 @@ extension Segmentio: UICollectionViewDelegateFlowLayout {
                                sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: segmentWidth(for: indexPath), height: collectionView.frame.height)
     }
-    
+
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               insetForSectionAt section: Int) -> UIEdgeInsets {
+        switch segmentioOptions.insetStyle {
+        case .none:
+            return .zero
+        case .centralized:
+            return insetForCentralizedElements()
+        case let .custom(insets: insets):
+            return insets
+        }
+    }
+
+    private func insetForCentralizedElements() -> UIEdgeInsets {
+        let firstItemIndexPath = IndexPath(row: 0, section: 0)
+        let firstItemWidth = segmentWidth(for: firstItemIndexPath)
+        let leftSpacing = (self.frame.width - firstItemWidth) / 2
+
+        let lastItemIndexPath = IndexPath(row: segmentioItems.count - 1, section: 0)
+        let lastItemWidth = segmentWidth(for: lastItemIndexPath)
+        let rightSpacing = (self.frame.width - lastItemWidth) / 2
+
+        return UIEdgeInsets(top: 0, left: leftSpacing, bottom: 0, right: rightSpacing)
+    }
 }
 
 // MARK: - UIScrollViewDelegate

--- a/Segmentio/Source/SegmentioOptions.swift
+++ b/Segmentio/Source/SegmentioOptions.swift
@@ -137,6 +137,13 @@ public enum SegmentioPosition {
     case fixed(maxVisibleItems: Int)
 }
 
+// MARK: - Inset
+public enum SegmentioInsetStyle {
+    case none
+    case centralized
+    case custom(insets: UIEdgeInsets)
+}
+
 // MARK: - Control options
 
 public enum SegmentioStyle: String {
@@ -197,6 +204,7 @@ public struct SegmentioOptions {
     var labelTextNumberOfLines: Int
     var states: SegmentioStates
     var animationDuration: CFTimeInterval
+    var insetStyle: SegmentioInsetStyle
     
     public init() {
         self.backgroundColor = .lightGray
@@ -212,6 +220,7 @@ public struct SegmentioOptions {
                                         selectedState: SegmentioState(),
                                         highlightedState: SegmentioState())
         self.animationDuration = 0.1
+        self.insetStyle = .none
     }
 
     public init(backgroundColor: UIColor = .lightGray,
@@ -226,7 +235,8 @@ public struct SegmentioOptions {
                 segmentStates: SegmentioStates = SegmentioStates(defaultState: SegmentioState(),
                                                                  selectedState: SegmentioState(),
                                                                  highlightedState: SegmentioState()),
-                animationDuration: CFTimeInterval = 0.1) {
+                animationDuration: CFTimeInterval = 0.1,
+                insetStyle: SegmentioInsetStyle = .none) {
         self.backgroundColor = backgroundColor
         self.segmentPosition = segmentPosition
         self.scrollEnabled = scrollEnabled
@@ -238,5 +248,6 @@ public struct SegmentioOptions {
         self.labelTextNumberOfLines = labelTextNumberOfLines
         self.states = segmentStates
         self.animationDuration = animationDuration
+        self.insetStyle = insetStyle
     }
 }


### PR DESCRIPTION
Currently in Segmentio isn't possible to customize appearance such as centralize the elements.
This implementation adds this feature, with three options:

1. None: default behaviour, with a zero inset
2. Centralized: automatically calculates the insets in order to centralise elements
3. Custom: uses the custom inset given by the user