### PR TITLE
added support to image tintcolor when image are always templated

### DIFF
--- a/Segmentio/Source/Cells/SegmentioCell.swift
+++ b/Segmentio/Source/Cells/SegmentioCell.swift
@@ -148,6 +148,7 @@ class SegmentioCell: UICollectionViewCell {
                 
         if (style != .onlyLabel) {
             segmentImageView?.image = selected ? selectedImage : image
+            segmentImageView?.tintColor = selected ? selectedState.imageTintColor : defaultState.imageTintColor
         }
     }
     

--- a/Segmentio/Source/SegmentioOptions.swift
+++ b/Segmentio/Source/SegmentioOptions.swift
@@ -50,15 +50,18 @@ public struct SegmentioState {
     var titleFont: UIFont
     var titleTextColor: UIColor
     var titleAlpha: CGFloat
+    var imageTintColor: UIColor
     
     public init(
         backgroundColor: UIColor = .clear,
         titleFont: UIFont = UIFont.systemFont(ofSize: UIFont.smallSystemFontSize),
         titleTextColor: UIColor = .black,
+        imageTintColor: UIColor? = nil,
         titleAlpha: CGFloat = 1) {
         self.backgroundColor = backgroundColor
         self.titleFont = titleFont
         self.titleTextColor = titleTextColor
+        self.imageTintColor = imageTintColor ?? titleTextColor
         self.titleAlpha = titleAlpha
     }
     


### PR DESCRIPTION
In SegmentioItem no tint color is set to the ImageView, so even when the image has a rendering mode equals to AlwaysTemplate it’ll be rendered with its original color.

I've added this feature and backward compatibility is ensured.

Best regards,

Patrick