### PR TITLE
Update swift tools version of Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 


### PR DESCRIPTION
When using this package via SPM, we encountered the error 'bringSubviewToFront' has been renamed to 'bringSubview(toFront:)' which we think is related to swift versions. Updating the swift version used in Package.swift to 5 as in the project, solves this problem.